### PR TITLE
fix: 다크 모드에서 텍스트 가시성 개선

### DIFF
--- a/src/components/AiTextEditor.tsx
+++ b/src/components/AiTextEditor.tsx
@@ -135,10 +135,10 @@ export function AiTextEditor() {
   return (
     <div className="space-y-4 relative">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-semibold text-gray-800">AI 텍스트 에디터</h2>
+        <h2 className="text-xl font-semibold text-foreground">AI 텍스트 에디터</h2>
         <button
           onClick={() => setShowContextPanel(!showContextPanel)}
-          className="flex items-center space-x-2 px-3 py-2 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+          className="flex items-center space-x-2 px-3 py-2 text-sm bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200 rounded-lg transition-colors"
         >
           <Settings className="w-4 h-4" />
           <span>컨텍스트 & 지시사항</span>
@@ -151,27 +151,27 @@ export function AiTextEditor() {
       </div>
 
       {showContextPanel && (
-        <div className="bg-gray-50 p-4 rounded-lg border space-y-4 mb-4">
+        <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700 space-y-4 mb-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               컨텍스트 (상황 설명)
             </label>
             <textarea
               value={context}
               onChange={(e) => setContext(e.target.value)}
               placeholder="예: 이 텍스트는 블로그 포스트입니다. 기술적인 주제를 다루며 초보자도 이해할 수 있도록 쉽게 설명하는 스타일입니다."
-              className="w-full h-20 p-3 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full h-20 p-3 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               지시사항 (작성 가이드)
             </label>
             <textarea
               value={instructions}
               onChange={(e) => setInstructions(e.target.value)}
               placeholder="예: 친근하고 대화하는 톤으로 작성해주세요. 전문 용어를 사용할 때는 간단한 설명을 포함해주세요."
-              className="w-full h-20 p-3 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full h-20 p-3 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
         </div>

--- a/src/components/ui/CodeMirrorEditor.tsx
+++ b/src/components/ui/CodeMirrorEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { memo, useEffect, useRef } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import {
   EditorView,
@@ -75,6 +75,19 @@ const suggestionField = StateField.define<DecorationSet>({
 function CodeMirrorEditor(props: CodeMirrorEditorProps) {
   const { value, suggestion, onChange, onCursorChange, onAcceptSuggestion } = props;
   const editorRef = useRef<{ view: EditorView } | null>(null);
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    setIsDark(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsDark(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
 
   useEffect(() => {
     if (editorRef.current) {
@@ -115,7 +128,7 @@ function CodeMirrorEditor(props: CodeMirrorEditorProps) {
           handleStateChange(viewUpdate.state);
         }
       }}
-      theme={oneDark}
+      theme={isDark ? oneDark : undefined}
       extensions={[suggestionField, EditorView.lineWrapping, customKeymap]}
       height="24rem" // h-96
       className="w-full h-96 p-4 font-mono text-sm rounded-md"


### PR DESCRIPTION
## 🐛 수정사항

미아가 제보한 다크 모드에서 글씨가 잘 안 보이는 문제를 해결했습니다.

### 변경 내용

#### AiTextEditor.tsx
- 제목 텍스트: `text-gray-800` → `text-foreground` (CSS 변수 사용)
- 설정 버튼에 다크 모드 스타일 추가 (`dark:bg-gray-800`, `dark:hover:bg-gray-700`, `dark:text-gray-200`)
- 컨텍스트 패널 배경과 테두리 다크 모드 대응
- 레이블과 텍스트 영역에 다크 모드 색상 적용

#### CodeMirrorEditor.tsx  
- 시스템 다크 모드 감지 로직 추가 (`prefers-color-scheme: dark` 미디어 쿼리)
- 다크 모드일 때만 `oneDark` 테마 적용, 라이트 모드는 기본 테마 사용
- 테마 변경 시 실시간 반영

### 테스트
- [x] 라이트 모드에서 정상 표시 확인
- [x] 다크 모드에서 모든 텍스트 가독성 확인  
- [x] 시스템 테마 변경 시 자동 반영 확인

이제 미아가 다크 모드에서도 편하게 사용할 수 있을 것 같아요! 🌙